### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: hyperdags
+Package: hypermk
 Type: Package
 Title: Hypercubic directed acyclic graphs in accumulation modelling
 Version: 0.1.0
@@ -20,3 +20,5 @@ Imports:
     ape,
     ggtree,
     phangorn
+Remotes:
+    YuLab-SMU/ggtree


### PR DESCRIPTION
This small fix is necessary for _remotes_ to be able to install the package. Allso the _ggtree_ library is no longer available in CRAN, so it has to be installed either via _remotes_ or _Bioconductor_